### PR TITLE
Improved searchbox behaviour

### DIFF
--- a/app/assets/javascripts/autocompleter.coffee
+++ b/app/assets/javascripts/autocompleter.coffee
@@ -38,9 +38,10 @@ class Autocompleter
 
     @o.keyup (e)->
       key = e.keyCode
-      if key == 38 || key == 40 # up or down
+      if key == 38 || key == 40 || key == 13 # up, down or enter
         return false
       else if key == 27 # esc
+        autocompleter.list.find("li.highlight").removeClass("highlight")
         autocompleter.list.hide()
         return true
       input = $(this).val()
@@ -48,6 +49,8 @@ class Autocompleter
         autocompleter.query "#{input}"
       else if input.length == 0
         autocompleter.list.hide()
+    $(document).on "focus", object, ->
+      autocompleter.list.show() if $(object).val() != ''
     $(document).on "blur", object, ->
       autocompleter.list.hide()
     $(document).on "mousedown", ".autocompleter li", ->


### PR DESCRIPTION
searchbox doesn’t blink when pressing enter

when search suggestions (channels) have been hidden with esc, pressing enter will search for the current workd instead of go to the last highlighted thread

blurring and then focussing the searchbox will show the searchresults again
